### PR TITLE
fix(portal): UX post-upload y folio en validación admin

### DIFF
--- a/src/components/InstanceDetailContent/InstanceDetailContent.tsx
+++ b/src/components/InstanceDetailContent/InstanceDetailContent.tsx
@@ -303,24 +303,52 @@ export const InstanceDetailContent: React.FC = () => {
         </section>
 
         {/* Current Status */}
-        {instance.current_step && !instance.requires_input && (
-          <section className="current-status-section">
-            <div className="container">
-              <div className="status-card">
-                <h2>Paso Actual</h2>
-                <div className="current-step">
-                  <div className="step-icon">
-                    <i className="icon-processing"></i>
-                  </div>
-                  <div className="step-info">
-                    <strong>Procesando: {instance.current_step}</strong>
-                    <p>Su solicitud está siendo procesada. La información se actualizará automáticamente.</p>
+        {instance.current_step && !instance.requires_input && (() => {
+          const currentStepProgress = instance.step_progress.find(
+            (s) => s.step_id === instance.current_step
+          );
+          const friendlyName = currentStepProgress?.name || instance.current_step;
+          const waitingForAdmin =
+            instance.waiting_for === 'child_workflow_completion' ||
+            (instance.waiting_for || '').includes('admin');
+          return (
+            <section className="current-status-section">
+              <div className="container">
+                <div className="status-card">
+                  <h2>{waitingForAdmin ? 'En revisión' : 'Paso Actual'}</h2>
+                  <div className="current-step">
+                    <div className="step-icon">
+                      <i className="icon-processing"></i>
+                    </div>
+                    <div className="step-info">
+                      <strong>{friendlyName}</strong>
+                      {waitingForAdmin ? (
+                        <>
+                          <p style={{ marginTop: '0.5rem' }}>
+                            Su solicitud fue recibida y está en revisión por un validador.
+                          </p>
+                          <p style={{ marginTop: '0.25rem' }}>
+                            <strong>Folio:</strong> <code>{id}</code>
+                          </p>
+                          <p style={{ marginTop: '0.25rem' }}>
+                            <strong>Plazo estimado de resolución:</strong> 21 días hábiles
+                          </p>
+                          <p style={{ marginTop: '0.25rem', color: '#666' }}>
+                            Recibirá notificación cuando la revisión se complete. Puede cerrar
+                            esta página; podrá consultar el estado en cualquier momento con
+                            este folio.
+                          </p>
+                        </>
+                      ) : (
+                        <p>Su solicitud está siendo procesada. La información se actualizará automáticamente.</p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
-          </section>
-        )}
+            </section>
+          );
+        })()}
       </main>
     </div>
   );

--- a/src/hooks/useWorkflowFormSubmission.ts
+++ b/src/hooks/useWorkflowFormSubmission.ts
@@ -26,6 +26,40 @@ export interface UseWorkflowFormSubmissionOptions {
 const DEFAULT_SUBMIT_CLEAR_MS = 2000;
 const DEFAULT_REWIND_CLEAR_MS = 1200;
 
+// Tras un submit exitoso, el executor del backend puede tardar en avanzar el
+// step (especialmente con S3UploadOperator que retorna PENDING_ASYNC). Si el
+// frontend dispara onAfterSubmit antes de que avance, el ciudadano percibe
+// "no pasó nada". Hacemos polling al endpoint de tracking hasta detectar
+// transición o agotar el presupuesto de tiempo.
+const POLL_INTERVAL_MS = 600;
+const POLL_TIMEOUT_MS = 12000;
+
+async function waitForStepTransition(
+  instanceId: string,
+  fromTaskId: string | undefined,
+  fromStatus: string | undefined
+): Promise<void> {
+  if (!instanceId || !fromTaskId) return;
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    await new Promise((r) => window.setTimeout(r, POLL_INTERVAL_MS));
+    try {
+      const progress = await workflowService.trackWorkflowInstance(instanceId);
+      const currentStep =
+        (progress as any).current_step ||
+        ((progress as any).input_form as any)?.current_step_id;
+      const status = (progress as any).status;
+      // Avanzó al siguiente step o el status cambió de paused/waiting
+      if (currentStep && currentStep !== fromTaskId) return;
+      if (fromStatus && status && status !== fromStatus) return;
+    } catch {
+      // Si el polling falla, no bloqueamos; salimos para dejar que el
+      // refetch normal de la UI muestre lo que sea que haya en el backend.
+      return;
+    }
+  }
+}
+
 /**
  * Centraliza la lógica que decide cómo enviar `data` al backend según el
  * `waiting_for` del step actual. Reglas (primer match gana):
@@ -126,9 +160,21 @@ export function useWorkflowFormSubmission(
               [`${taskId}_selections`]: transformedSelections,
             });
           } else {
+            const fileKeys = new Set(
+              data._files && typeof data._files === 'object'
+                ? Object.keys(data._files)
+                : []
+            );
             const formData = new FormData();
             Object.entries(data).forEach(([key, value]) => {
               if (key === '_files' || value === undefined || value === null) return;
+              // Si el field ya tiene un File en _files, omitimos el value
+              // de data[key]. Si lo dejaramos, se appendería como segundo
+              // valor de la misma key (string JSON o filename) y el backend
+              // termina perdiendo el File real, dejando un dict
+              // {filename, content_type, size} sin contenido y los uploads
+              // a S3 fallan con "No valid file content or path provided".
+              if (fileKeys.has(key)) return;
               const stringValue =
                 typeof value === 'object' ? JSON.stringify(value) : value.toString();
               formData.append(key, stringValue);
@@ -146,6 +192,12 @@ export function useWorkflowFormSubmission(
 
         if (response?.success) {
           setSubmissionSuccess(response.message || defaultMessage);
+          // Esperar a que el backend efectivamente avance el step antes de
+          // pedirle a la UI que recargue. Sin esto, el executor async puede
+          // seguir procesando (S3UploadOperator → PENDING_ASYNC) y el
+          // refetch trae el mismo step, dándole al ciudadano la impresión
+          // de que "no pasó nada" hasta que aprieta Actualizar.
+          await waitForStepTransition(id, taskId, (inst as any)?.status);
           optionsRef.current.onAfterSubmit?.();
           if (successMs > 0) {
             window.setTimeout(() => setSubmissionSuccess(null), successMs);


### PR DESCRIPTION
## Resumen

Atiende 3 reportes del spreadsheet de cambios CONAPESCA Junio 2026 (project [Trámites CONAPESCA — Correcciones Junio 2026](https://github.com/orgs/TrazabilidadCONAPESCA/projects/2)).

| Issue | Descripción |
|---|---|
| #118 | "Paso N no permite cargar el documento. Omite 'Enviar Información', pero al dar 'Actualizar' avanza al paso N+1" |
| #113 | Aviso de Arribo: ciudadano no veía folio claro al llegar a validación admin |
| #114 | Aviso de Cosecha: idem |

## Cambios

### `useWorkflowFormSubmission.ts` — race post-submit y duplicado de file fields

**Race condition con uploads:** `S3UploadOperator` retorna `PENDING_ASYNC` y el `executor.resume_instance()` corre en background. El submit respondía éxito antes de que el paso avanzara, así que `onAfterSubmit` (→ `fetchProgress`) traía el mismo step y la UI parecía no responder. El ciudadano apretaba "Actualizar" y entonces sí veía el siguiente paso, dando la impresión de bug en "Enviar Información".

Se agrega `waitForStepTransition` que hace polling al endpoint `/public/track/{id}` cada 600ms (timeout 12s) hasta detectar que `current_step` o `status` cambian. Solo entonces se invoca `onAfterSubmit`. Si el polling falla, sale silenciosamente y deja que el refetch normal recupere el estado.

**File fields duplicados:** Al construir `FormData`, si un campo tenía un `File` en `_files`, se appendía dos veces (una con string filename, otra con el File real). El backend Starlette tomaba el primer valor (string) y perdía el File, fallando con "No valid file content or path provided". Se omite el value cuando la key ya está en `_files`.

### `InstanceDetailContent.tsx` — folio prominente "En revisión"

Cuando `instance.waiting_for === 'child_workflow_completion'`, la sección "Paso Actual" ahora se renderea como card dedicada "En revisión" con:
- Nombre amigable del step (de `step_progress`, no el `task_id` crudo).
- Folio: `<code>{instance_id}</code>` visible.
- Plazo estimado: 21 días hábiles.
- Mensaje: "Recibirá notificación cuando la revisión se complete. Puede cerrar esta página; podrá consultar el estado en cualquier momento con este folio."

## Test plan

- [ ] Iniciar un trámite con upload (registro RNPA paso 6, por ejemplo); apretar "Enviar Información" y confirmar que el siguiente paso aparece solo (puede tardar 1-3s con spinner), sin requerir "Actualizar".
- [ ] Llegar a `administrative_validation` en cualquier trámite (aviso de arribo, RNPA, etc.); verificar que el card muestra "En revisión", folio, plazo y mensaje.
- [ ] Que no se rompa el flujo de Catastro (mismo hook usado en múltiples tenants).