### PR TITLE
feat: subir archivo en captura de imagen y aviso de requisitos PDF

### DIFF
--- a/src/components/ActiveWorkflowForm/ActiveWorkflowForm.tsx
+++ b/src/components/ActiveWorkflowForm/ActiveWorkflowForm.tsx
@@ -240,6 +240,7 @@ function renderBody(
           description={
             inputForm.description || 'Toma una selfie para verificar tu identidad'
           }
+          allowFileUpload={!!inputForm.allow_file_upload}
           onSubmit={onSubmit}
           isSubmitting={isSubmitting}
         />
@@ -253,6 +254,7 @@ function renderBody(
             inputForm.description ||
             'Captura ambos lados de tu documento de identidad'
           }
+          allowFileUpload={!!inputForm.allow_file_upload}
           onSubmit={onSubmit}
           isSubmitting={isSubmitting}
         />

--- a/src/components/DataCollectionForm.tsx
+++ b/src/components/DataCollectionForm.tsx
@@ -1,6 +1,28 @@
 import React, { useState, useCallback } from 'react';
 import { entityService } from '../services/entityService';
 
+// Aviso con las características que debe reunir un documento para cargarse
+// correctamente (formatos, tamaño y nombre sin acentos/caracteres especiales).
+const FileRequirementsNote: React.FC = () => (
+  <div className="file-requirements-note" style={{
+    marginTop: '0.5rem',
+    padding: '0.6rem 0.8rem',
+    backgroundColor: '#f1f8ff',
+    border: '1px solid #cfe3ff',
+    borderRadius: '6px',
+    fontSize: '0.8rem',
+    color: '#445',
+    textAlign: 'left'
+  }}>
+    <strong>📋 El documento debe cumplir:</strong>
+    <ul style={{ margin: '0.35rem 0 0', paddingLeft: '1.1rem' }}>
+      <li>Formato PDF, JPG o PNG.</li>
+      <li>Tamaño máximo: 100 MB.</li>
+      <li>Nombre del archivo sin acentos ni caracteres especiales (ej. "aviso_arribo.pdf", no "Avisó (1).pdf").</li>
+    </ul>
+  </div>
+);
+
 // Simple debounce function without external dependencies
 function debounce<T extends (...args: any[]) => any>(
   func: T,
@@ -485,6 +507,7 @@ export const DataCollectionForm: React.FC<DataCollectionFormProps> = ({
                 </div>
               )}
             </div>
+            <FileRequirementsNote />
           </div>
         );
       }
@@ -1003,10 +1026,11 @@ export const DataCollectionForm: React.FC<DataCollectionFormProps> = ({
                 <div className="upload-placeholder">
                   <span className="upload-icon">⬆️</span>
                   <span>Click to upload {field.label}</span>
-                  <small>PDF, JPG, PNG, DOC (max 10MB)</small>
+                  <small>PDF, JPG, PNG (máx 100MB)</small>
                 </div>
               )}
             </div>
+            <FileRequirementsNote />
           </div>
         );
 

--- a/src/components/capture/IDCapture.tsx
+++ b/src/components/capture/IDCapture.tsx
@@ -5,22 +5,45 @@ interface IDCaptureProps {
   description: string;
   onSubmit: (data: Record<string, any>) => void;
   isSubmitting?: boolean;
+  allowFileUpload?: boolean;
 }
 
 export const IDCapture: React.FC<IDCaptureProps> = ({
   title,
   description,
   onSubmit,
-  isSubmitting = false
+  isSubmitting = false,
+  allowFileUpload = false
 }) => {
   const [frontFile, setFrontFile] = useState<File | null>(null);
   const [backFile, setBackFile] = useState<File | null>(null);
+  const [frontUploaded, setFrontUploaded] = useState(false);
+  const [backUploaded, setBackUploaded] = useState(false);
   const [currentSide, setCurrentSide] = useState<'front' | 'back' | null>(null);
   const [isStreaming, setIsStreaming] = useState(false);
   const [permissionStatus, setPermissionStatus] = useState<'unknown' | 'granted' | 'denied'>('unknown');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const videoRef = useRef<HTMLVideoElement>(null);
+  const frontInputRef = useRef<HTMLInputElement>(null);
+  const backInputRef = useRef<HTMLInputElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
+
+  const handleFileUpload = useCallback((side: 'front' | 'back', e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setErrorMessage('');
+    if (!file.type.startsWith('image/')) {
+      setErrorMessage('El archivo debe ser una imagen (JPG, PNG).');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      (file as any).dataURL = reader.result as string;
+      if (side === 'front') { setFrontFile(file); setFrontUploaded(true); }
+      else { setBackFile(file); setBackUploaded(true); }
+    };
+    reader.readAsDataURL(file);
+  }, []);
 
   // Check camera permission status
   const checkCameraPermission = async () => {
@@ -181,25 +204,40 @@ export const IDCapture: React.FC<IDCaptureProps> = ({
     e.preventDefault();
     if (frontFile && backFile) {
       const timestamp = new Date().toISOString();
-      const metadata = {
-        user_agent: navigator.userAgent,
-        platform: navigator.platform,
-        screen_resolution: `${window.screen.width}x${window.screen.height}`,
-        capture_method: 'getUserMedia',
-        capture_source: 'canvas',
-        media_devices_available: true,
-        captured_at: timestamp,
-        timestamp_unix: Date.now(),
-        stream_active: true,
-        live_capture: true,
-        document_sides: ['front', 'back'],
-        browser_fingerprint: {
-          language: navigator.language,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          color_depth: window.screen.colorDepth,
-          pixel_ratio: window.devicePixelRatio
-        }
-      };
+      const anyUploaded = frontUploaded || backUploaded;
+      // Si algún lado proviene de archivo subido no es captura en vivo; el
+      // backend (allow_file_upload) omite las validaciones de captura en vivo.
+      const metadata = anyUploaded
+        ? {
+            user_agent: navigator.userAgent,
+            platform: navigator.platform,
+            capture_method: 'file_upload',
+            capture_source: 'file',
+            media_devices_available: false,
+            captured_at: timestamp,
+            timestamp_unix: Date.now(),
+            live_capture: false,
+            document_sides: ['front', 'back']
+          }
+        : {
+            user_agent: navigator.userAgent,
+            platform: navigator.platform,
+            screen_resolution: `${window.screen.width}x${window.screen.height}`,
+            capture_method: 'getUserMedia',
+            capture_source: 'canvas',
+            media_devices_available: true,
+            captured_at: timestamp,
+            timestamp_unix: Date.now(),
+            stream_active: true,
+            live_capture: true,
+            document_sides: ['front', 'back'],
+            browser_fingerprint: {
+              language: navigator.language,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              color_depth: window.screen.colorDepth,
+              pixel_ratio: window.devicePixelRatio
+            }
+          };
 
       onSubmit({
         _files: {
@@ -214,8 +252,12 @@ export const IDCapture: React.FC<IDCaptureProps> = ({
   const handleRetake = (side: 'front' | 'back') => {
     if (side === 'front') {
       setFrontFile(null);
+      setFrontUploaded(false);
+      if (frontInputRef.current) frontInputRef.current.value = '';
     } else {
       setBackFile(null);
+      setBackUploaded(false);
+      if (backInputRef.current) backInputRef.current.value = '';
     }
   };
 
@@ -341,7 +383,37 @@ export const IDCapture: React.FC<IDCaptureProps> = ({
               >
                 📷 Activar Cámara (Frente)
               </button>
-            ) : (
+            ) : null}
+            {!frontFile && allowFileUpload && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <button
+                  type="button"
+                  onClick={() => frontInputRef.current?.click()}
+                  style={{
+                    padding: '0.85rem 1.5rem',
+                    backgroundColor: '#fff',
+                    color: '#ff9800',
+                    border: '2px solid #ff9800',
+                    borderRadius: '8px',
+                    cursor: 'pointer',
+                    fontSize: '0.95rem',
+                    fontWeight: 'bold',
+                    width: '100%',
+                    maxWidth: '250px'
+                  }}
+                >
+                  📁 Subir archivo (Frente)
+                </button>
+                <input
+                  ref={frontInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleFileUpload('front', e)}
+                  style={{ display: 'none' }}
+                />
+              </div>
+            )}
+            {frontFile && (
               <div>
                 <img
                   src={(frontFile as any).dataURL}
@@ -396,7 +468,38 @@ export const IDCapture: React.FC<IDCaptureProps> = ({
               >
                 📷 Activar Cámara (Reverso)
               </button>
-            ) : (
+            ) : null}
+            {!backFile && allowFileUpload && (
+              <div style={{ marginTop: '0.75rem' }}>
+                <button
+                  type="button"
+                  onClick={() => backInputRef.current?.click()}
+                  disabled={!frontFile}
+                  style={{
+                    padding: '0.85rem 1.5rem',
+                    backgroundColor: '#fff',
+                    color: frontFile ? '#ff9800' : '#bdbdbd',
+                    border: `2px solid ${frontFile ? '#ff9800' : '#bdbdbd'}`,
+                    borderRadius: '8px',
+                    cursor: frontFile ? 'pointer' : 'not-allowed',
+                    fontSize: '0.95rem',
+                    fontWeight: 'bold',
+                    width: '100%',
+                    maxWidth: '250px'
+                  }}
+                >
+                  📁 Subir archivo (Reverso)
+                </button>
+                <input
+                  ref={backInputRef}
+                  type="file"
+                  accept="image/*"
+                  onChange={(e) => handleFileUpload('back', e)}
+                  style={{ display: 'none' }}
+                />
+              </div>
+            )}
+            {backFile && (
               <div>
                 <img
                   src={(backFile as any).dataURL}

--- a/src/components/capture/SelfieCapture.tsx
+++ b/src/components/capture/SelfieCapture.tsx
@@ -5,19 +5,23 @@ interface SelfieCaptureProps {
   description: string;
   onSubmit: (data: Record<string, any>) => void;
   isSubmitting?: boolean;
+  allowFileUpload?: boolean;
 }
 
 export const SelfieCapture: React.FC<SelfieCaptureProps> = ({
   title,
   description,
   onSubmit,
-  isSubmitting = false
+  isSubmitting = false,
+  allowFileUpload = false
 }) => {
   const [capturedFile, setCapturedFile] = useState<File | null>(null);
+  const [isUploaded, setIsUploaded] = useState(false);
   const [isStreaming, setIsStreaming] = useState(false);
   const [permissionStatus, setPermissionStatus] = useState<'unknown' | 'granted' | 'denied'>('unknown');
   const [errorMessage, setErrorMessage] = useState<string>('');
   const videoRef = useRef<HTMLVideoElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
   const streamRef = useRef<MediaStream | null>(null);
 
   // Check camera permission status
@@ -163,33 +167,66 @@ export const SelfieCapture: React.FC<SelfieCaptureProps> = ({
     }, 'image/jpeg', 0.98); // Maximum quality compression
   }, []);
 
+  const handleFileUpload = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setErrorMessage('');
+    if (!file.type.startsWith('image/')) {
+      setErrorMessage('El archivo debe ser una imagen (JPG, PNG).');
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      (file as any).dataURL = reader.result as string;
+      setCapturedFile(file);
+      setIsUploaded(true);
+    };
+    reader.readAsDataURL(file);
+  }, []);
+
   const retakePhoto = useCallback(() => {
     setCapturedFile(null);
-    startCamera();
-  }, [startCamera]);
+    setIsUploaded(false);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+    if (!allowFileUpload) startCamera();
+  }, [startCamera, allowFileUpload]);
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     if (capturedFile) {
       const timestamp = new Date().toISOString();
-      const metadata = {
-        user_agent: navigator.userAgent,
-        platform: navigator.platform,
-        screen_resolution: `${window.screen.width}x${window.screen.height}`,
-        capture_method: 'getUserMedia',
-        capture_source: 'canvas',
-        media_devices_available: true,
-        captured_at: timestamp,
-        timestamp_unix: Date.now(),
-        stream_active: true,
-        live_capture: true,
-        browser_fingerprint: {
-          language: navigator.language,
-          timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-          color_depth: window.screen.colorDepth,
-          pixel_ratio: window.devicePixelRatio
-        }
-      };
+      // El archivo subido NO es captura en vivo: el backend (allow_file_upload)
+      // omite las validaciones de captura en vivo para esta fuente.
+      const metadata = isUploaded
+        ? {
+            user_agent: navigator.userAgent,
+            platform: navigator.platform,
+            capture_method: 'file_upload',
+            capture_source: 'file',
+            media_devices_available: false,
+            captured_at: timestamp,
+            timestamp_unix: Date.now(),
+            live_capture: false,
+            original_filename: capturedFile.name
+          }
+        : {
+            user_agent: navigator.userAgent,
+            platform: navigator.platform,
+            screen_resolution: `${window.screen.width}x${window.screen.height}`,
+            capture_method: 'getUserMedia',
+            capture_source: 'canvas',
+            media_devices_available: true,
+            captured_at: timestamp,
+            timestamp_unix: Date.now(),
+            stream_active: true,
+            live_capture: true,
+            browser_fingerprint: {
+              language: navigator.language,
+              timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+              color_depth: window.screen.colorDepth,
+              pixel_ratio: window.devicePixelRatio
+            }
+          };
 
       onSubmit({
         _files: {
@@ -247,10 +284,42 @@ export const SelfieCapture: React.FC<SelfieCaptureProps> = ({
           >
             📷 Activar Cámara
           </button>
+
+          {allowFileUpload && (
+            <div style={{ marginTop: '0.5rem' }}>
+              <div style={{ color: '#999', fontSize: '0.85rem', margin: '0.5rem 0' }}>— o —</div>
+              <button
+                type="button"
+                onClick={() => fileInputRef.current?.click()}
+                style={{
+                  padding: '0.85rem 1.75rem',
+                  backgroundColor: '#fff',
+                  color: '#2196f3',
+                  border: '2px solid #2196f3',
+                  borderRadius: '8px',
+                  cursor: 'pointer',
+                  fontSize: '1rem',
+                  fontWeight: 'bold'
+                }}
+              >
+                📁 Subir archivo
+              </button>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept="image/*"
+                onChange={handleFileUpload}
+                style={{ display: 'none' }}
+              />
+            </div>
+          )}
+
           <p style={{ color: '#666', fontSize: '0.9rem', marginTop: '1rem' }}>
             {permissionStatus === 'denied'
               ? 'Los permisos están denegados. Haz clic en el candado 🔒 en la barra de direcciones para permitir el acceso.'
-              : 'Al hacer clic, tu navegador solicitará permiso para acceder a la cámara.'}
+              : allowFileUpload
+                ? 'Puedes subir un archivo de imagen o tomar la foto con la cámara.'
+                : 'Al hacer clic, tu navegador solicitará permiso para acceder a la cámara.'}
           </p>
         </div>
       )}


### PR DESCRIPTION
Correcciones del spreadsheet de junio 2026 (lado portal ciudadano):

- **#104**: `SelfieCapture` e `IDCapture` aceptan `allowFileUpload` (desde `form_config`) y ofrecen un botón "Subir archivo" además de la cámara, enviando la imagen con metadata `file_upload` (no captura en vivo).
- **#116**: `FileRequirementsNote` junto a los campos de archivo indica formatos aceptados, tamaño máximo (100 MB) y recomendación de nombre sin acentos ni caracteres especiales, para evitar errores de carga.

Compila (`tsc -b && vite build`) y desplegado localmente para verificación.