### PR TITLE
feat: aplicar constraints de campos y unificar PDF (descarga=vista=impresión)

### DIFF
--- a/src/components/DataCollectionForm.tsx
+++ b/src/components/DataCollectionForm.tsx
@@ -50,6 +50,16 @@ export interface FormField {
     min?: number;
     max?: number;
   };
+  // Root-level constraints (convention used by backend workflows for top-level
+  // fields). Read in addition to `validation` for enforcement and live input attrs.
+  min?: number;
+  max?: number;
+  step?: number;
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  // Date fields: disallow dates before today (no retroactive dates)
+  minToday?: boolean;
   helpText?: string;
   autoCompleteConfig?: {
     triggerOnLength?: number;
@@ -584,28 +594,43 @@ export const DataCollectionForm: React.FC<DataCollectionFormProps> = ({
       return `${field.label} is required`;
     }
 
-    if (value && field.validation) {
-      const { pattern, minLength, maxLength, min, max } = field.validation;
+    if (value !== undefined && value !== null && value !== '') {
+      // Constraints can be declared at the field root (backend workflow
+      // convention) or under `field.validation`; read both, root takes priority.
+      const pattern = field.pattern ?? field.validation?.pattern;
+      const minLength = field.minLength ?? field.validation?.minLength;
+      const maxLength = field.maxLength ?? field.validation?.maxLength;
+      const min = field.min ?? field.validation?.min;
+      const max = field.max ?? field.validation?.max;
 
       if (pattern && !new RegExp(pattern).test(value)) {
         return `${field.label} format is invalid`;
       }
 
-      if (minLength && value.length < minLength) {
+      if (minLength !== undefined && value.length < minLength) {
         return `${field.label} must be at least ${minLength} characters`;
       }
 
-      if (maxLength && value.length > maxLength) {
+      if (maxLength !== undefined && value.length > maxLength) {
         return `${field.label} must be no more than ${maxLength} characters`;
       }
 
       if (field.type === 'number') {
         const numValue = parseFloat(value);
         if (min !== undefined && numValue < min) {
-          return `${field.label} must be at least ${min}`;
+          return `${field.label} debe ser al menos ${min}`;
         }
         if (max !== undefined && numValue > max) {
-          return `${field.label} must be no more than ${max}`;
+          return `${field.label} no debe ser mayor que ${max}`;
+        }
+      }
+
+      if (field.type === 'date' && field.minToday) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const selected = new Date(value);
+        if (!Number.isNaN(selected.getTime()) && selected < today) {
+          return `${field.label} no puede ser anterior a la fecha actual`;
         }
       }
     }
@@ -1133,7 +1158,31 @@ export const DataCollectionForm: React.FC<DataCollectionFormProps> = ({
           </div>
         );
 
-      default:
+      default: {
+        // Apply constraints declared at the field root or under `validation`
+        // so the browser enforces them live (HTML5) in addition to validateField.
+        const todayIso = (() => {
+          const d = new Date();
+          d.setHours(0, 0, 0, 0);
+          return d.toISOString().slice(0, 10);
+        })();
+        const numberAttrs = field.type === 'number'
+          ? {
+              min: field.min ?? field.validation?.min,
+              max: field.max ?? field.validation?.max,
+              step: field.step ?? 'any',
+            }
+          : {};
+        const dateAttrs = field.type === 'date' && field.minToday
+          ? { min: todayIso }
+          : {};
+        const textAttrs = field.type === 'text' || field.type === 'email' || field.type === 'phone'
+          ? {
+              maxLength: field.maxLength ?? field.validation?.maxLength,
+              minLength: field.minLength ?? field.validation?.minLength,
+              pattern: field.pattern ?? field.validation?.pattern,
+            }
+          : {};
         return (
           <input
             {...commonProps}
@@ -1142,8 +1191,12 @@ export const DataCollectionForm: React.FC<DataCollectionFormProps> = ({
             value={formData[field.id] || ''}
             onChange={(e) => handleInputChange(field.id, e.target.value)}
             className="form-input"
+            {...numberAttrs}
+            {...dateAttrs}
+            {...textAttrs}
           />
         );
+      }
     }
   };
 

--- a/src/components/signature/EntityViewer.tsx
+++ b/src/components/signature/EntityViewer.tsx
@@ -37,9 +37,6 @@ import {
   Info,
   CheckCircle,
   Schedule,
-  Wallet,
-  Apple,
-  Android,
 } from '@mui/icons-material';
 import axios from 'axios';
 
@@ -80,7 +77,6 @@ export const EntityViewer: React.FC<EntityViewerProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [htmlContent, setHtmlContent] = useState<string>('');
-  const [walletLoading, setWalletLoading] = useState(false);
 
   // Load HTML content on component mount
   useEffect(() => {
@@ -174,107 +170,6 @@ export const EntityViewer: React.FC<EntityViewerProps> = ({
     }
   }, [entity.id, entity.has_signature, apiBaseUrl]);
 
-  // Detect platform
-  const detectPlatform = () => {
-    const userAgent = navigator.userAgent.toLowerCase();
-    if (/iphone|ipad|ipod/.test(userAgent)) {
-      return 'ios';
-    } else if (/android/.test(userAgent)) {
-      return 'android';
-    }
-    return 'desktop';
-  };
-
-  // Handle Apple Wallet
-  const handleAddToAppleWallet = useCallback(async () => {
-    try {
-      setWalletLoading(true);
-      setError(null);
-
-      const response = await axios.get(
-        `${apiBaseUrl}/entities/${entity.id}/wallet/apple`,
-        { responseType: 'blob' }
-      );
-
-      // Create download link for .pkpass file
-      const blob = new Blob([response.data], { type: 'application/vnd.apple.pkpass' });
-      const url = window.URL.createObjectURL(blob);
-      const link = document.createElement('a');
-      link.href = url;
-      link.download = `${entity.name || entity.type}_${entity.id}.pkpass`;
-      document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
-      window.URL.revokeObjectURL(url);
-    } catch (error) {
-      const errorMessage = axios.isAxiosError(error)
-        ? error.response?.data?.detail || error.message
-        : 'Error al agregar a Apple Wallet';
-      setError(errorMessage);
-    } finally {
-      setWalletLoading(false);
-    }
-  }, [entity.id, entity.name, entity.type, apiBaseUrl]);
-
-  // Handle Google Wallet
-  const handleAddToGoogleWallet = useCallback(async () => {
-    try {
-      setWalletLoading(true);
-      setError(null);
-
-      const response = await axios.get(
-        `${apiBaseUrl}/entities/${entity.id}/wallet/google`
-      );
-
-      // Open Google Wallet save URL
-      if (response.data.save_url) {
-        window.open(response.data.save_url, '_blank');
-      } else {
-        throw new Error('No se pudo generar el enlace de Google Wallet');
-      }
-    } catch (error) {
-      const errorMessage = axios.isAxiosError(error)
-        ? error.response?.data?.detail || error.message
-        : 'Error al agregar a Google Wallet';
-      setError(errorMessage);
-    } finally {
-      setWalletLoading(false);
-    }
-  }, [entity.id, apiBaseUrl]);
-
-  // Handle wallet button click
-  const handleWalletAction = useCallback(() => {
-    const platform = detectPlatform();
-
-    if (platform === 'ios') {
-      handleAddToAppleWallet();
-    } else if (platform === 'android') {
-      handleAddToGoogleWallet();
-    } else {
-      // Desktop - show options or default to Apple
-      handleAddToAppleWallet();
-    }
-  }, [handleAddToAppleWallet, handleAddToGoogleWallet]);
-
-  const getWalletButtonText = () => {
-    const platform = detectPlatform();
-    if (platform === 'ios') {
-      return 'Agregar a Apple Wallet';
-    } else if (platform === 'android') {
-      return 'Agregar a Google Wallet';
-    }
-    return 'Agregar a Wallet';
-  };
-
-  const getWalletIcon = () => {
-    const platform = detectPlatform();
-    if (platform === 'ios') {
-      return <Apple />;
-    } else if (platform === 'android') {
-      return <Android />;
-    }
-    return <Wallet />;
-  };
 
 
   // Get signature status color and icon
@@ -715,16 +610,6 @@ export const EntityViewer: React.FC<EntityViewerProps> = ({
             Descargar PDF
           </Button>
 
-          <Button
-            startIcon={getWalletIcon()}
-            onClick={handleWalletAction}
-            disabled={walletLoading}
-            variant="outlined"
-            color="secondary"
-          >
-            {getWalletButtonText()}
-          </Button>
-
           {entity.has_signature && (
             <Button
               startIcon={<CheckCircle />}
@@ -736,7 +621,7 @@ export const EntityViewer: React.FC<EntityViewerProps> = ({
             </Button>
           )}
 
-          {(loading || walletLoading) && <CircularProgress size={20} />}
+          {loading && <CircularProgress size={20} />}
         </CardActions>
       </Card>
     </Box>


### PR DESCRIPTION
## Resumen
### Validación de constraints en formularios dinámicos
`DataCollectionForm.tsx` ahora aplica los constraints declarados en la **raíz** del campo (la convención de los workflows del backend), no solo dentro de `field.validation`:
- `number`: `min`/`max`/`step` (atributos en el input + validación pre-submit)
- texto: `minLength`/`maxLength`/`pattern`
- `date`: `minToday` (bloquea fechas retroactivas)

Antes estos límites se ignoraban (el form definía `min`/`max` en la raíz pero el componente solo leía `field.validation`), permitiendo p.ej. potencia >115 HP o fechas pasadas.

### PDF y Wallet (`EntityViewer.tsx`)
- Se elimina el botón **'Agregar a Wallet'** y todo su código (sin funcionalidad).
- La descarga, la vista y la impresión del documento ya comparten el mismo template (ver cambio correspondiente en el backend).

## Pruebas
- Build (`tsc -b && vite build`) OK.
- E2E en vivo: el servidor rechaza valores fuera de rango; PDF/HTML consistentes.